### PR TITLE
[Plan Submission] Swoop — NBN 100

### DIFF
--- a/workers/price-sync/community-sources/swoop-nbn-100.json
+++ b/workers/price-sync/community-sources/swoop-nbn-100.json
@@ -1,0 +1,8 @@
+{
+  "provider": "Swoop",
+  "url": "https://www.swoop.com.au/nbn/nbn-100-plan",
+  "networkType": "nbn",
+  "downloadSpeed": 100,
+  "notes": "Swoop NBN 100 plan - user reported missing from NetBargains. They also have other speed tiers.",
+  "submittedAt": "2026-03-30T05:11:36.347Z"
+}


### PR DESCRIPTION
## Plan Submission

| Field | Value |
|-------|-------|
| **Provider** | Swoop |
| **Network** | NBN |
| **Download Speed** | 100 Mbps |
| **Upload Speed** | _Not provided_ |
| **Plan URL** | https://www.swoop.com.au/nbn/nbn-100-plan |
| **CIS URL** | _Not provided_ |

## Notes

Swoop NBN 100 plan - user reported missing from NetBargains. They also have other speed tiers.

---
*Submitted via the community plan submission form.*