### PR TITLE
[Plan Submission] Origin — NBN 100/40

### DIFF
--- a/workers/price-sync/community-sources/origin-nbn-100-40.json
+++ b/workers/price-sync/community-sources/origin-nbn-100-40.json
@@ -1,0 +1,10 @@
+{
+  "provider": "Origin",
+  "url": "https://www.originenergy.com.au/internet/plans/?cid=ps:re:mktsa_half_price_internet_campaign_fy26_q3:gl&gclsrc=aw.ds&gad_source=1&gad_campaignid=17529119988&gbraid=0AAAAAoomPZYKyCwllC3lZKc6E6de5lbNA&gclid=CjwKCAjwvqjOBhAGEiwAngeQnab9LJ8sb4L2DtXOGHZ4Pccdr6mT7Ua3f690oJyJOHVdzU78uUI_PhoC_bEQAvD_BwE",
+  "networkType": "nbn",
+  "cisUrl": "https://www.originenergy.com.au/wp-content/uploads/117/261003_origin_internet_nbn.pdf",
+  "downloadSpeed": 100,
+  "uploadSpeed": 40,
+  "notes": "$59.50 month for 6 months then $119 ongoing.   There is no direct page.",
+  "submittedAt": "2026-03-31T06:56:23.980Z"
+}


### PR DESCRIPTION
## Plan Submission

| Field | Value |
|-------|-------|
| **Provider** | Origin |
| **Network** | NBN |
| **Download Speed** | 100 Mbps |
| **Upload Speed** | 40 Mbps |
| **Plan URL** | https://www.originenergy.com.au/internet/plans/?cid=ps:re:mktsa_half_price_internet_campaign_fy26_q3:gl&gclsrc=aw.ds&gad_source=1&gad_campaignid=17529119988&gbraid=0AAAAAoomPZYKyCwllC3lZKc6E6de5lbNA&gclid=CjwKCAjwvqjOBhAGEiwAngeQnab9LJ8sb4L2DtXOGHZ4Pccdr6mT7Ua3f690oJyJOHVdzU78uUI_PhoC_bEQAvD_BwE |
| **CIS URL** | https://www.originenergy.com.au/wp-content/uploads/117/261003_origin_internet_nbn.pdf |

## Notes

$59.50 month for 6 months then $119 ongoing.   There is no direct page.

---
*Submitted via the community plan submission form.*